### PR TITLE
fix(snat): derive eth1 gateway from subnet instead of nonexistent route

### DIFF
--- a/runonce.sh
+++ b/runonce.sh
@@ -1,15 +1,22 @@
-#!/bin/bash -x
+#!/bin/bash -ex
 
-# attach the ENI
-end_time=$((SECONDS + 180))
-while [ $SECONDS -lt $end_time ] && ! ip link show dev eth1; do
+REGION="$(/opt/aws/bin/ec2-metadata -z | sed 's/placement: \(.*\).$/\1/')"
+INSTANCE_ID="$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)"
+
+# attach the ENI (attach once, then wait for the link to appear)
+if ! ip link show dev eth1 >/dev/null 2>&1; then
   aws ec2 attach-network-interface \
-    --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
-    --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)" \
+    --region "$REGION" \
+    --instance-id "$INSTANCE_ID" \
     --device-index 1 \
     --network-interface-id "${eni_id}"
-    sleep 5
+fi
+
+end_time=$((SECONDS + 180))
+while [ $SECONDS -lt $end_time ] && ! ip link show dev eth1 >/dev/null 2>&1; do
+  sleep 2
 done
+ip link show dev eth1 >/dev/null 2>&1 || { echo "eth1 never appeared after attach" >&2; exit 1; }
 
 # start SNAT
 systemctl enable snat

--- a/snat.service
+++ b/snat.service
@@ -1,10 +1,14 @@
 [Unit]
-After=ec2net-ifup@eth1.service
+After=ec2net-ifup@eth1.service network-online.target
+Wants=network-online.target
 Description = SNAT via ENI eth1
 
 [Service]
-ExecStart = /opt/nat/snat.sh
 Type = oneshot
+RemainAfterExit = yes
+ExecStart = /opt/nat/snat.sh
+Restart = on-failure
+RestartSec = 10
 StandardOutput = kmsg+console
 
 [Install]

--- a/snat.sh
+++ b/snat.sh
@@ -1,15 +1,26 @@
 #!/bin/bash
-set -x
+set -euxo pipefail
 
-# wait for eth1
+# wait for eth1 link
 end_time=$((SECONDS + 180))
-while [ $SECONDS -lt $end_time ] && ! ip link show dev eth1; do
+while [ $SECONDS -lt $end_time ] && ! ip link show dev eth1 >/dev/null 2>&1; do
+  sleep 1
+done
+ip link show dev eth1 >/dev/null 2>&1 || { echo "eth1 never appeared" >&2; exit 1; }
+
+# wait for eth1 to actually get an IPv4 address (the real race vs. the old script)
+end_time=$((SECONDS + 180))
+while [ $SECONDS -lt $end_time ] && ! ip -4 -o addr show dev eth1 | grep -q 'inet '; do
   sleep 1
 done
 
-if ! ip link show dev eth1; then
-  exit 1
-fi
+ETH1_CIDR=$(ip -4 -o addr show dev eth1 | awk '{print $4; exit}')
+[ -n "${ETH1_CIDR:-}" ] || { echo "eth1 has no IPv4 address" >&2; exit 1; }
+
+# AWS VPC router = first host of the subnet (network + 1). ipcalc ships on AL2.
+NETWORK=$(ipcalc -n "$ETH1_CIDR" | cut -d= -f2)
+GW=$(awk -F. '{print $1"."$2"."$3"."$4+1}' <<<"$NETWORK")
+[ -n "$GW" ] || { echo "could not determine eth1 gateway" >&2; exit 1; }
 
 # enable IP forwarding and NAT
 sysctl -q -w net.ipv4.ip_forward=1
@@ -17,25 +28,17 @@ sysctl -q -w net.ipv4.conf.eth1.send_redirects=0
 sysctl -q -w net.ipv4.conf.eth1.rp_filter=0
 sysctl -q -w net.ipv4.conf.all.rp_filter=0
 
-iptables -A PREROUTING -t mangle -i eth1 -j MARK --set-mark 1
-iptables -t nat -A POSTROUTING -o eth1 -j MASQUERADE
+# idempotent iptables (-C check before -A so re-runs don't duplicate)
+iptables -t mangle -C PREROUTING -i eth1 -j MARK --set-mark 1 2>/dev/null \
+  || iptables -t mangle -A PREROUTING -i eth1 -j MARK --set-mark 1
+iptables -t nat -C POSTROUTING -o eth1 -j MASQUERADE 2>/dev/null \
+  || iptables -t nat -A POSTROUTING -o eth1 -j MASQUERADE
 
-echo "from all fwmark 1 lookup nat" >> /etc/sysconfig/network-scripts/rule-eth1
+# policy-routing table for marked (forwarded) traffic
+grep -q '^100[[:space:]]\+nat$' /etc/iproute2/rt_tables || echo "100 nat" >> /etc/iproute2/rt_tables
+grep -q 'fwmark 1 lookup nat' /etc/sysconfig/network-scripts/rule-eth1 2>/dev/null \
+  || echo "from all fwmark 1 lookup nat" >> /etc/sysconfig/network-scripts/rule-eth1
 
-echo "100 nat" >>/etc/iproute2/rt_tables
-GW=$(ip route show 0.0.0.0/0 dev eth1 | cut -d\  -f3)
-ip route add default via $GW dev eth1 table nat
-ip rule add fwmark 1 lookup nat
+ip route replace default via "$GW" dev eth1 table nat        # replace = idempotent
+ip rule list | grep -q "fwmark 0x1 lookup nat" || ip rule add fwmark 1 lookup nat
 ip route flush cache
-# switch the default route to eth1
-#ip route del default dev eth0
-#ip route
-
-# wait for network connection
-#curl --retry 10 --retry-delay 5 --connect-timeout 10 --max-time 60 http://www.example.com
-#if [ $? -ne 0 ]; then
-#  echo "curl exited with an error"
-#fi
-
-# reestablish connections
-# systemctl restart amazon-ssm-agent.service


### PR DESCRIPTION
The instance failed to get a NAT default route because snat.sh read the gateway from `ip route show 0.0.0.0/0 dev eth1`, which is always empty on a secondary ENI (ec2-net-utils keeps eth1's default route in a separate per-interface table, not the main table). GW ended up empty and `ip route add default via dev eth1 table nat` failed.

snat.sh:
- derive gateway from eth1's subnet (ipcalc -n + 1), the AWS VPC router
- set -euxo pipefail so failures surface instead of being swallowed
- wait for eth1's IPv4 address, not just the link (boot timing race)
- make iptables/ip-rule/route/rt_tables operations idempotent

runonce.sh:
- attach the ENI once then poll for the link (avoid repeated attach calls)
- resolve region/instance-id once

snat.service:
- RemainAfterExit + Restart=on-failure for transient failures
- order after network-online.target